### PR TITLE
Change heuristics

### DIFF
--- a/src/FastCholesky.jl
+++ b/src/FastCholesky.jl
@@ -75,7 +75,7 @@ function fastcholesky!(A::Matrix{<:BlasFloat})
     n = LinearAlgebra.checksquare(A)
     # Heuristics, the built-in version is faster for large inputs
     # Perhaps due to the better cache usage, the Base version fallbacks to LAPACK
-    return n < 100 ? _fastcholesky!(n, A) : cholesky!(A; check=false)
+    return n < 20 ? _fastcholesky!(n, A) : cholesky!(A; check=false)
 end
 
 function _fastcholesky!(n, A::AbstractMatrix)


### PR DESCRIPTION
On my machine the LinearAlgebra version seems to perform better for a larger range now. This PR changes the threshold between using `fastcholesky` and the regular `cholesky`