### PR TITLE
Add docs stating `cholsqrt` != `sqrt`

### DIFF
--- a/src/FastCholesky.jl
+++ b/src/FastCholesky.jl
@@ -127,7 +127,8 @@ end
 """
     cholsqrt(input)
 
-Calculate the square root of the input matrix `input` using Cholesky factorization. This function is an alias for `fastcholesky(input).L`.
+Calculate the Cholesky square root of the input matrix `input`. This function is an alias for `fastcholesky(input).L`.
+NOTE: This is not equal to the standard matrix square root used in literature, which requires the result to be symmetric.
 
 ```jldoctest 
 julia> A = [4.0 2.0; 2.0 5.0];


### PR DESCRIPTION
The `cholsqrt` implementation does not return the matrix square root as defined in literature (https://en.wikipedia.org/wiki/Square_root_of_a_matrix) which requires it to be symmetric.