### PR TITLE
Make fastcholesky! a bit more tolerant to errors in the input

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
         version:
           - '1.9'
           - '1.10'
+          - '1.11'
         os:
           - ubuntu-latest
         arch:
@@ -48,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.10'
+          version: '1.11'
       - name: Configure doc environment
         run: |
           julia --project=docs/ -e '

--- a/src/FastCholesky.jl
+++ b/src/FastCholesky.jl
@@ -42,7 +42,7 @@ function fastcholesky!(x::UniformScaling)
 end
 
 """
-    fastcholesky!(input; fallback_gmw81=true, symmetrize_input=true, tol=PositiveFactorizations.default_δ(input))
+    fastcholesky!(input; fallback_gmw81=true, symmetrize_input=true, gmw81_tol=PositiveFactorizations.default_δ(input), symmetric_tol=1e-8)
 
 Calculate the Cholesky factorization of the input matrix `input` in-place. This function is an in-place version of `fastcholesky`.
 It first checks if the input matrix is symmetric, and if it is, it will use the built-in Cholesky factorization by wrapping the input in a `Hermitian` matrix.

--- a/test/fastcholesky_tests.jl
+++ b/test/fastcholesky_tests.jl
@@ -51,7 +51,11 @@
 
         nonposdefmatrix = Matrix(Diagonal(-ones(size)))
 
-        @test !issuccess(fastcholesky!(nonposdefmatrix))
+        # We test that the fallback to GMW81 works, for non-positive definite matrices
+        # the GMW81 algorihtm should succeed, but the built-in Cholesky factorization should fail
+        @test_throws ArgumentError fastcholesky!(nonposdefmatrix; fallback_gmw81 = false, symmetrize_input = false)
+        @test issuccess(fastcholesky!(nonposdefmatrix; fallback_gmw81 = true))
+        @test issuccess(fastcholesky!(nonposdefmatrix; fallback_gmw81 = false, symmetrize_input = true))
     end
 end
 


### PR DESCRIPTION
This PR improves the robustness of the fastcholesky function by making it more tolerant to imperfect input. The function now first checks whether the input matrix is slightly non-symmetric. If so, it proceeds with the original procedure but wraps the input in Hermitian. If the matrix is more clearly non-symmetric, it attempts to symmetrize it and issues a warning to indicate potential issues with the input. In both cases, if Cholesky factorization fails due to the matrix not being positive definite, the function will retry using the GMW81 algorithm (if the corresponding flag is enabled).