### PR TITLE
Fix type assertion regression

### DIFF
--- a/test/fastcholesky_setuptests.jl
+++ b/test/fastcholesky_setuptests.jl
@@ -27,6 +27,7 @@ function make_rand_inputs(::Type{T}, size) where {T}
         make_rand_diagonal(T, size),
         make_rand_posdef(T, size),
         make_rand_hermitian(T, size),
+        view(make_rand_hermitian(T, size), 1:size, 1:size),
         oneunit(T) * I(size),
     ]
     # StaticArrays do not work efficiently for large inputs anyway

--- a/test/fastcholesky_tests.jl
+++ b/test/fastcholesky_tests.jl
@@ -179,3 +179,11 @@ end
 
     @test isempty(String(take!(io)))
 end
+
+@testitem "Regression from FastCholesky.jl 1.4.0 - type assertion should work fine" begin 
+    using LinearAlgebra
+
+    @testset let A = view(Matrix([ 1.0 0.0; 0.0 1.0 ]), 1:2, 1:2)
+        @test cholinv(A) * A ≈ I
+    end
+end


### PR DESCRIPTION
Our tests for RxInfer are failing due to FastCholesky 1.4.0

In order to make JET tests and compiler happy in FastCholesky 1.4.0 I put a type-assert on the return type of the function. In turned out not to be correct actually... For example if you do a cholesky over view of the matrix it actually still returns the matrix. This PR removes the type assert. In order to make the compiler happy I'm now calling the actually `cholesky!` function at the end of our `fastcholesky!` but that statement should be unreachable anyway. 