### PR TITLE
Add support for blocked arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ StaticArraysCore = "1"
 julia = "1.6"
 
 [extras]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -27,4 +28,4 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StaticArrays", "StaticArraysCore", "ReTestItems", "JET"]
+test = ["Test", "BlockArrays", "StaticArrays", "StaticArraysCore", "ReTestItems", "JET"]

--- a/src/FastCholesky.jl
+++ b/src/FastCholesky.jl
@@ -34,7 +34,9 @@ true
 ```
 """
 function fastcholesky(input::AbstractMatrix)
-    return fastcholesky!(copy(input))
+    A = zeros(eltype(input), size(input))
+    copyto!(A, input)
+    return fastcholesky!(A)
 end
 
 fastcholesky(input::Number) = cholesky(input)
@@ -119,7 +121,7 @@ function fastcholesky!(
             )
         end
         if !haskey(ENV, NO_WARN_NON_SYMMETRIC_ENV)
-            @warn lazy"The input matrix to `FastCholesky` is not symmetric. The tolerance threshold is `$symmetric_tol`. Set `$(NO_WARN_NON_SYMMETRIC_ENV)=1` environment variable to suppress this warning. Set `$(THROW_ERROR_NON_SYMMETRIC_ENV)=1` to throw an error instead of a warning."    
+            @warn lazy"The input matrix to `FastCholesky` is not symmetric. The tolerance threshold is `$symmetric_tol`. Set `$(NO_WARN_NON_SYMMETRIC_ENV)=1` environment variable to suppress this warning. Set `$(THROW_ERROR_NON_SYMMETRIC_ENV)=1` to throw an error instead of a warning."
         end
         if symmetrize_input
             A = (A + A') / 2

--- a/test/fastcholesky_setuptests.jl
+++ b/test/fastcholesky_setuptests.jl
@@ -1,4 +1,4 @@
-using Test, FastCholesky, LinearAlgebra, StaticArrays, StaticArraysCore, JET
+using Test, FastCholesky, LinearAlgebra, StaticArrays, StaticArraysCore, JET, BlockArrays
 
 const SupportedTypes = (Float32, Float64, BigFloat)
 
@@ -22,11 +22,16 @@ function make_rand_lowertriangular(::Type{T}, size) where {T}
     return LowerTriangular(10rand(T, size, size))
 end
 
+function make_rand_block_matrix(::Type{T}, size) where {T}
+    return BlockedArray(make_rand_posdef(T, 2size), [size, size], [size, size])
+end
+
 function make_rand_inputs(::Type{T}, size) where {T}
     inputs = [
         make_rand_diagonal(T, size),
         make_rand_posdef(T, size),
         make_rand_hermitian(T, size),
+        make_rand_block_matrix(T, size),
         view(make_rand_hermitian(T, size), 1:size, 1:size),
         oneunit(T) * I(size),
     ]

--- a/test/fastcholesky_tests.jl
+++ b/test/fastcholesky_tests.jl
@@ -224,3 +224,30 @@ end
         @test cholinv(A) * A ≈ I
     end
 end
+
+@testitem "BlockArrays support" begin
+    include("fastcholesky_setuptests.jl")
+
+    @testset "Case 1" begin
+        L = randn(8, 8)
+        M = L * L' + 10I
+        @test cholinv(M) * M ≈ I
+    end
+
+    @testset "Case 2" begin
+        B = mortar(reshape([Diagonal(ones(8)), Diagonal(zeros(8)), Diagonal(zeros(8)), Diagonal(ones(8))], 2, 2))
+        @test cholinv(B) * B ≈ I
+    end
+
+    @testset "Case 3" begin
+        B = BlockArrays.BlockDiagonal([Diagonal(ones(2)), Diagonal(ones(2)), Diagonal(ones(2)), Diagonal(ones(2))])
+        @test cholinv(B) * B ≈ I
+    end
+
+    @testset "Case 4" begin
+        B = BlockArrays.BlockDiagonal([
+            Matrix(Diagonal(ones(2))), Matrix(Diagonal(ones(2))), Matrix(Diagonal(ones(2))), Matrix(Diagonal(ones(2)))
+        ])
+        @test cholinv(B) * B ≈ I
+    end
+end


### PR DESCRIPTION
We use them in ExponentialFamily and the recent update broke this functionality